### PR TITLE
Various fixes to fix build and kill some error messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd perl-dbi git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD https://raw.githubusercontent.com/JackSlateur/perl-ip2as/master/ip2as.pm /us
 
 FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi perl-dbd-sqlite git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi perl-dbd-sqlite git php81-fpm php81-sqlite3 ttf-dejavu tzdata perl-net-patricia perl-json-xs && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest
+FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd git php5-fpm ttf-dejavu tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd git php81-fpm ttf-dejavu tzdata && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 
@@ -12,23 +12,22 @@ RUN curl --location http://search.cpan.org/CPAN/authors/id/E/EL/ELISA/Net-sFlow-
     && cd Net-sFlow-0.11/ \
     && perl Makefile.PL ; make ; make install
 
-RUN curl --location http://search.cpan.org/CPAN/authors/id/R/RC/RCLAMP/Text-Glob-0.09.tar.gz | tar -xzf - \
-    && cd Text-Glob-0.09/ \
+RUN curl --location https://cpan.metacpan.org/authors/id/R/RC/RCLAMP/Text-Glob-0.11.tar.gz | tar -xzf - \
+    && cd Text-Glob-0.11/ \
     && perl Makefile.PL ; make ; make install
 
 RUN curl --location  http://search.cpan.org/CPAN/authors/id/R/RC/RCLAMP/Number-Compare-0.03.tar.gz | tar -xzf - \
     && cd Number-Compare-0.03/ \
     && perl Makefile.PL ; make ; make install
 
-RUN rm -Rf Net-sFlow-0.11 File-Find-Rule-0.34 Text-Glob-0.09 Number-Compare-0.03
+RUN rm -Rf Net-sFlow-0.11 File-Find-Rule-0.34 Text-Glob-0.11 Number-Compare-0.03
 
 RUN git clone https://github.com/manuelkasper/AS-Stats.git
 
 RUN rm -Rf /var/www/localhost && \
     mv AS-Stats/www/* /var/www
 
-### NGINX + PHP5-FPM
-RUN mkdir /run/nginx/
+### NGINX + PHP81-FPM
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN mkdir -p /etc/nginx/sites-available/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.17 as builder
 RUN apk add --no-cache perl perl-app-cpanminus make perl-dev musl-dev gcc && rm -rf /var/cache/apk/*
 RUN cpanm File::Find::Rule@0.34 Net::sFlow@0.11 Text::Glob@0.11 Number::Compare@0.03 TryCatch@1.003002
+ADD https://raw.githubusercontent.com/JackSlateur/perl-ip2as/master/ip2as.pm /usr/local/lib/perl5/site_perl/ip2as.pm
 
 FROM alpine:3.17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN cpanm File::Find::Rule@0.34 Net::sFlow@0.11 Text::Glob@0.11 Number::Compare@
 
 FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi perl-dbd-sqlite git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd git php81-fpm ttf-dejavu tzdata && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool make perl-rrd git php81-fpm php81-sqlite3 ttf-dejavu tzdata && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod +x /usr/sbin/stats-day
 ADD files/startup.sh /root
 ADD files/supervisord.conf /etc/supervisord.conf
 
-COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local /usr/local
 
 RUN chmod +x /root/startup.sh
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c",  "/etc/supervisord.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.17 as builder
 RUN apk add --no-cache perl perl-app-cpanminus make perl-dev musl-dev gcc && rm -rf /var/cache/apk/*
 RUN cpanm File::Find::Rule@0.34 Net::sFlow@0.11 Text::Glob@0.11 Number::Compare@0.03 TryCatch@1.003002
+RUN apk add --no-cache perl-doc && rm -rf /var/cache/apk/*
 RUN cpanm Net::Patricia@1.22
 ADD https://raw.githubusercontent.com/JackSlateur/perl-ip2as/master/ip2as.pm /usr/local/lib/perl5/site_perl/ip2as.pm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM alpine:3.17 as builder
 RUN apk add --no-cache perl perl-app-cpanminus make perl-dev musl-dev gcc && rm -rf /var/cache/apk/*
 RUN cpanm File::Find::Rule@0.34 Net::sFlow@0.11 Text::Glob@0.11 Number::Compare@0.03 TryCatch@1.003002
+RUN cpanm Net::Patricia@1.22
 ADD https://raw.githubusercontent.com/JackSlateur/perl-ip2as/master/ip2as.pm /usr/local/lib/perl5/site_perl/ip2as.pm
 
 FROM alpine:3.17
 
-RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi perl-dbd-sqlite git php81-fpm php81-sqlite3 ttf-dejavu tzdata perl-net-patricia perl-json-xs && rm -rf /var/cache/apk/*
+RUN apk add --no-cache supervisor nginx bash curl perl rrdtool perl-rrd perl-dbi perl-dbd-sqlite git php81-fpm php81-sqlite3 ttf-dejavu tzdata perl-json-xs && rm -rf /var/cache/apk/*
 
 WORKDIR /root/
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ __Important: you must use tabs, not spaces, to separate fields!__
     SFLOW             set 1 if you want enable SFlow
     SFLOW_PORT        set udp port for SFlow daemon
     SFLOW_ASN         set your asn number for SFlow daemon
+    SFLOW_PEERAS      set 1 if you want enable peer-as statistics
+
+### IP<->ASM mapping
+
+    IP2AS_PATH        set to path (inside container) containing JSON file for IP<->ASN mapping
 
 ### TimeZone
 

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -22,9 +22,19 @@ if [[ $SFLOW == 1 ]] ; then
 
   # Own AS Number is required for sflow
   args+=("-a" "$SFLOW_ASN")
+
+  # Enable peer-as statistics if requested
+  if [[ $SFLOW_PEERAS == 1 ]] ; then
+    args+=("-n")
+  fi
 else
   # Disable sFlow
   args+=("-P" "0")
+fi
+
+# Enable IP<->ASN mapping with provided JSON file path
+if [[ -v IP2AS_PATH ]]; then
+  args+=("-m" "$IP2AS_PATH")
 fi
 
 # lance AS-Stats

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -41,9 +41,9 @@ fi
 nohup /root/AS-Stats/bin/asstatd.pl -r /data/as-stats/rrd -k /data/as-stats/conf/knownlinks "${args[@]}" &
 
 # Mise à l'heure
-if [ -n $TZ ] ; then
-  cp /usr/share/zoneinfo/$TZ /etc/localtime
-  echo $TZ > /etc/timezone
+if [[ -n $TZ ]] ; then
+  cp "/usr/share/zoneinfo/$TZ" /etc/localtime
+  echo "$TZ" > /etc/timezone
 else
   cp /usr/share/zoneinfo/UTC /etc/localtime
   echo UTC > /etc/timezone

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,13 +1,14 @@
 [supervisord]
 nodaemon=true
 logfile=/var/log/supervisord.log
+user=root
 
 [program:crond]
-command=/usr/sbin/crond
+command=/usr/sbin/crond -f
 priority=2
 
 [program:php-fpm]
-command=/usr/bin/php-fpm
+command=/usr/sbin/php-fpm81 -F
 priority=5
 
 [program:nginx]


### PR DESCRIPTION
This project needed a little bit of spring cleaning to make it actually buildable!

The existing Dockerfile was not buildable at all because of depending on "latest" alpine, which has changed quite a lot in 6 years. I've stabilized this by pointing at a recent version of alpine.

It was also using PHP5, this is upgraded to PHP8.1.

Various runtime dependencies (perl modules) were completely broken, and I'm not sure how they ever worked, but I ended up completely redoing how perl dependencies are handled. Where possible, I've used alpine's pre-built perl libraries, but in the many cases it's not possible, I've added a seperate perl module build stage where the perl modules can be installed and in some cases built (requiring a C compiler, etc, that shouldn't make it into the final image...)

Also a few other dependencies were fixed.

Finally, a few changes were made to the supervisor configuration to:

- Reflect the correct path for the php-fpm binary in the new version
- Silence an error message that supervisor is running as the wrong user
- Run cron in the foreground so that supervisor can properly monitor it